### PR TITLE
Fix missing babel preset

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ const WPConfig = {
     loaders: [{
       test: /\.jsx?$/,
       exclude: /(node_modules)/,
-      loaders: ['babel?{ "presets": ["es2015-loose", "react"], "plugins": ["transform-react-inline-elements"] }']
+      loaders: ['babel?{ "presets": [["es2015", {"loose": true}], "react"], "plugins": ["transform-react-inline-elements"] }']
     }]
   },
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-core": "^6.9.1",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-react-inline-elements": "^6.8.0",
-    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.5.0",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-gh-pages": "^0.5.4",


### PR DESCRIPTION
The gulp build seems to be broken because `es2015-loose` preset is missing. The package has now been [replaced](https://github.com/bkonkle/babel-preset-es2015-loose) by `es2015` preset with a flag.

![screen shot 2016-12-02 at 16 12 38](https://cloud.githubusercontent.com/assets/2567083/20838953/044f69ba-b8ab-11e6-8b87-7036d6047240.png)

I took also the opportunity to update the `babel-preset-es2015` version. 😎 
